### PR TITLE
[Fixed] チーム情報の操作に関しての機能を整えること #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@
 yarn-debug.log*
 .yarn-integrity
 /public/uploads
-memo.html
+note.html

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 yarn-debug.log*
 .yarn-integrity
 /public/uploads
+memo.html

--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,25 @@
+begin
+  require "hirb"
+rescue LoadError
+  puts "no hirb :("
+end
+
+ if defined? Hirb
+  # Slightly dirty hack to fully support in-session Hirb.disable/enable toggling
+  Hirb::View.instance_eval do
+    def enable_output_method
+      @output_method = true
+      @old_print = Pry.config.print
+      Pry.config.print = proc do |*args|
+        Hirb::View.view_or_page_output(args[1]) || @old_print.call(*args)
+      end
+    end
+
+     def disable_output_method
+      Pry.config.print = @old_print
+      @output_method = nil
+    end
+  end
+
+   Hirb.enable
+end

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'rails-erd'
+  gem 'hirb-unicode-steakknife'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    choice (0.2.0)
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
@@ -147,6 +148,10 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hirb (0.7.3)
+    hirb-unicode-steakknife (0.0.9)
+      hirb (~> 0.5)
+      unicode-display_width (~> 1.1)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -249,6 +254,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.2.0)
@@ -303,6 +313,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-graphviz (1.2.4)
     ruby-progressbar (1.9.0)
     rubyzip (1.2.1)
     sass (3.5.6)
@@ -397,6 +408,7 @@ DEPENDENCIES
   faker
   friendly_id (~> 5.1.0)
   guard-rspec
+  hirb-unicode-steakknife
   jbuilder (~> 2.5)
   jquery-rails
   letter_opener_web
@@ -409,6 +421,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 5.2.0)
   rails-controller-testing
+  rails-erd
   redcarpet (~> 2.3.0)
   rspec-parameterized
   rspec-rails
@@ -429,4 +442,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -2,18 +2,18 @@ class AssignsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    team = Team.friendly.find(params[:team_id])
+    @team = Team.friendly.find(params[:team_id])
     user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
     if user
-      team.invite_member(user)
-      if team.valid?
-        redirect_to team_url(team), notice: I18n.t('views.messages.assigned')
+      @team.invite_member(user)
+      if @team.valid?
+        redirect_to team_url(@team), notice: I18n.t('views.messages.assigned')
       else
         render template: 'teams/show'
         # redirect_to team_url(@team), notice: I18n.t('views.messages.failed_to_assign')
       end
     else
-      redirect_to team_url(team), notice: I18n.t('views.messages.failed_to_assign')
+      redirect_to team_url(@team), notice: I18n.t('views.messages.failed_to_assign')
     end
   end
 

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -1,5 +1,6 @@
 class AssignsController < ApplicationController
   before_action :authenticate_user!
+  before_action :possible_to_destroy_authentification, only: [:destroy]
 
   def create
     @team = Team.friendly.find(params[:team_id])
@@ -9,6 +10,7 @@ class AssignsController < ApplicationController
       if @team.valid?
         redirect_to team_url(@team), notice: I18n.t('views.messages.assigned')
       else
+        flash.now[:notice] = I18n.t('views.messages.failed_to_assign')
         render template: 'teams/show'
         # redirect_to team_url(@team), notice: I18n.t('views.messages.failed_to_assign')
       end
@@ -18,7 +20,13 @@ class AssignsController < ApplicationController
   end
 
   def destroy
+    @user = current_user
     assign = Assign.find(params[:id])
+    if assign.user_id == current_user.id
+      assign.destroy
+      flash.now[:notice] = I18n.t('views.messages.user_page_transition')
+      render template: "users/show" and return
+    end
     destroy_message = assign_destroy(assign, assign.user)
 
     redirect_to team_url(params[:team_id]), notice: destroy_message

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -24,8 +24,9 @@ class AssignsController < ApplicationController
     assign = Assign.find(params[:id])
     if assign.user_id == current_user.id
       assign.destroy
-      flash.now[:notice] = I18n.t('views.messages.user_page_transition')
-      render template: "users/show" and return
+      flash[:notice] = I18n.t('views.messages.user_page_transition')
+      redirect_to user_url(params[:user_id]) and return
+      # render template: "users/show" and return
     end
     destroy_message = assign_destroy(assign, assign.user)
 

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -59,4 +59,13 @@ class AssignsController < ApplicationController
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
+
+  def possible_to_destroy_authentification
+    @team = Team.find_by(name: params[:team_id].to_s)
+    assign = Assign.find(params[:id])
+    unless (assign.user_id == current_user.id) || (@team.owner_id == current_user.id)
+      flash.now[:notice] = I18n.t('views.messages.destroy_notification')
+      render template: 'teams/show'
+    end
+  end
 end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -6,7 +6,12 @@ class AssignsController < ApplicationController
     user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
     if user
       team.invite_member(user)
-      redirect_to team_url(team), notice: I18n.t('views.messages.assigned')
+      if team.valid?
+        redirect_to team_url(team), notice: I18n.t('views.messages.assigned')
+      else
+        render template: 'teams/show'
+        # redirect_to team_url(@team), notice: I18n.t('views.messages.failed_to_assign')
+      end
     else
       redirect_to team_url(team), notice: I18n.t('views.messages.failed_to_assign')
     end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :possible_to_edit_authentification, only: [:edit]
 
   def index
     @teams = Team.all
@@ -55,5 +56,12 @@ class TeamsController < ApplicationController
 
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+  end
+
+  def possible_to_edit_authentification
+    if @team.owner_id != current_user.id
+      flash.now[:notice] = I18n.t('views.messages.edit_notification')
+      render :show
+    end
   end
 end

--- a/app/models/assign.rb
+++ b/app/models/assign.rb
@@ -1,4 +1,5 @@
 class Assign < ApplicationRecord
+  validates :team_id, uniqueness: { scope: :user_id }
   belongs_to :user
   belongs_to :team
 end

--- a/app/views/layouts/login/application.html.erb
+++ b/app/views/layouts/login/application.html.erb
@@ -16,6 +16,9 @@
       <!-- /.login-logo -->
       <div class="card">
         <div class="card-body login-card-body">
+          <% flash.each do |name, msg| %>
+            <%= content_tag :div, msg, :id => "flash_#{name}" if msg.is_a?(String) %>
+          <% end %>
           <%= yield %>
         </div>
         <!-- /.login-card-body -->

--- a/app/views/layouts/login/application.html.erb
+++ b/app/views/layouts/login/application.html.erb
@@ -16,9 +16,6 @@
       <!-- /.login-logo -->
       <div class="card">
         <div class="card-body login-card-body">
-          <% flash.each do |name, msg| %>
-            <%= content_tag :div, msg, :id => "flash_#{name}" if msg.is_a?(String) %>
-          <% end %>
           <%= yield %>
         </div>
         <!-- /.login-card-body -->

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -47,11 +47,13 @@
               <table class="table">
                 <tbody>
                   <% @team.assigns.each do |assign| %>
-                    <tr>
-                      <td><%= image_tag 'default.jpg', size: '40x40' %></td>
-                      <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign),method: :delete, data:{confirm: I18n.t('views.messages.delete_confirmatin')}, class: 'btn btn-sm btn-danger' %></td>
-                    </tr>
+                    <% if assign.id != nil %>
+                      <tr>
+                        <td><%= image_tag 'default.jpg', size: '40x40' %></td>
+                        <td><%= assign.user.email %></td>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign),method: :delete, data:{confirm: I18n.t('views.messages.delete_confirmatin')}, class: 'btn btn-sm btn-danger' %></td>
+                      </tr>
+                    <% end %>
                   <% end %>
                 </tbody>
               </table>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -50,7 +50,7 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign),method: :delete, data:{confirm: "????????????"}, class: 'btn btn-sm btn-danger' %></td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,3 +1,12 @@
+<% if @team && @team.errors.any? %>
+   <div id="error_explanation">
+     <ul>
+     <% @team.errors.full_messages.each do |message| %>
+       <li><%= message %></li>
+     <% end %>
+     </ul>
+   </div>
+ <% end %>
 <p id="notice"><%= notice %></p>
 
 <div class="row">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -50,7 +50,7 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign),method: :delete, data:{confirm: "????????????"}, class: 'btn btn-sm btn-danger' %></td>
+                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign),method: :delete, data:{confirm: I18n.t('views.messages.delete_confirmatin')}, class: 'btn btn-sm btn-danger' %></td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -28,13 +28,13 @@ ja:
     models:
       user: "ユーザ"
       assign: "チームアサイン"
-       team: "チーム"
-       agenda: "アジェンダ"
-       argicle: "トピック"
-       comment: "コメント"
-     attributes:
-       team:
-         assigns: チームアサイン
+      team: "チーム"
+      agenda: "アジェンダ"
+      argicle: "トピック"
+      comment: "コメント"
+    attributes:
+      team:
+        assigns: チームアサイン
   devise:
     confirmations:
       confirmed: "アカウントを登録しました。"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -27,6 +27,14 @@ ja:
         updated_at: "更新日"
     models:
       user: "ユーザ"
+      assign: "チームアサイン"
+       team: "チーム"
+       agenda: "アジェンダ"
+       argicle: "トピック"
+       comment: "コメント"
+     attributes:
+       team:
+         assigns: チームアサイン
   devise:
     confirmations:
       confirmed: "アカウントを登録しました。"
@@ -51,9 +59,9 @@ ja:
         instruction: "次のリンクでメールアドレスの確認が完了します。"
         subject: "アカウントの有効化について"
       email_changed:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       password_change:
         greeting: "%{recipient}様"
         message: "パスワードが再設定されたことを通知します。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -252,7 +252,7 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
       edit_notification: 'チームのオーナーのみ編集可能です'
-      destroy_notification: 'アサインメンバー自身かチームのオーナーのみ削除可能です'
+      destroy_notification: 'チームメンバー自身かチームのオーナーのみ削除可能です'
       user_page_transition: '削除しました  アサインチームから抜けました'
       delete_confirmatin: '削除してもよろしいですか'
     button:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -254,6 +254,7 @@ ja:
       edit_notification: 'チームのオーナーのみ編集可能です'
       destroy_notification: 'アサインメンバー自身かチームのオーナーのみ削除可能です'
       user_page_transition: '削除しました  アサインチームから抜けました'
+      delete_confirmatin: '削除してもよろしいですか'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -251,6 +251,9 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      edit_notification: 'チームのオーナーのみ編集可能です'
+      destroy_notification: 'アサインメンバー自身かチームのオーナーのみ削除可能です'
+      user_page_transition: '削除しました  アサインチームから抜けました'
     button:
       submit: '投稿'
       edit: '編集'

--- a/note.html
+++ b/note.html
@@ -1,0 +1,12 @@
+
+# 322: define_method(name) do |*args|
+#   => 323:   last = args.last
+#      324:   options = \
+#      325:     case last
+#      326:     when Hash
+#      327:       args.pop
+#      328:     when ActionController::Parameters
+#      329:       args.pop.to_h
+#      330:     end
+#      331:   helper.call self, args, options
+#      332: end


### PR DESCRIPTION
- チームのメンバー削除はチームのオーナーか、チームのユーザー自身しができないよう設定
- チームの編集はチームのオーナーのみができるよう設定
- チームメンバー招待時メンバーを重複してい招待できないよう設定
- チームメンバー削除時確認アラート追加