### PR TITLE
[Fixed]#6チーム情報の操作に関しての機能を整えること

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -1,5 +1,6 @@
 class AssignsController < ApplicationController
   before_action :authenticate_user!
+  before_action :possible_to_destroy_authentification, only: [:destroy]
 
   def create
     team = Team.friendly.find(params[:team_id])
@@ -13,7 +14,13 @@ class AssignsController < ApplicationController
   end
 
   def destroy
+    @user = current_user
     assign = Assign.find(params[:id])
+    if assign.user_id == current_user.id
+      assign.destroy
+      flash.now[:notice] = I18n.t('views.messages.user_page_transition')
+      render template: "users/show" and return
+    end
     destroy_message = assign_destroy(assign, assign.user)
 
     redirect_to team_url(params[:team_id]), notice: destroy_message

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -53,4 +53,13 @@ class AssignsController < ApplicationController
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
+
+  def possible_to_destroy_authentification
+    @team = Team.find_by(name: params[:team_id].to_s)
+    assign = Assign.find(params[:id])
+    unless (assign.user_id == current_user.id) || (@team.owner_id == current_user.id)
+      flash.now[:notice] = I18n.t('views.messages.destroy_notification')
+      render template: 'teams/show'
+    end
+  end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :possible_to_edit_authentification, only: [:edit]
 
   def index
     @teams = Team.all
@@ -55,5 +56,12 @@ class TeamsController < ApplicationController
 
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+  end
+
+  def possible_to_edit_authentification
+    if @team.owner_id != current_user.id
+      flash.now[:notice] = I18n.t('views.messages.edit_notification')
+      render :show
+    end
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -252,7 +252,7 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
       edit_notification: 'チームのオーナーのみ編集可能です'
-      destroy_notification: 'アサインメンバー自身かチームのオーナーのみ削除可能です'
+      destroy_notification: 'チームメンバー自身かチームのオーナーのみ削除可能です'
       user_page_transition: '削除しました  アサインチームから抜けました'
     button:
       submit: '投稿'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -251,6 +251,9 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      edit_notification: 'チームのオーナーのみ編集可能です'
+      destroy_notification: 'アサインメンバー自身かチームのオーナーのみ削除可能です'
+      user_page_transition: '削除しました  アサインチームから抜けました'
     button:
       submit: '投稿'
       edit: '編集'

--- a/memo.html
+++ b/memo.html
@@ -1,0 +1,16 @@
+<%= link_to "hoge", {controller: "users", action: "update", user_id: 1}, method: :post %>
+<td><%= link_to I18n.t('views.button.delegation'), {controller:"teams", action: "team_owner_delegation",method: :patch,
+class: 'btn btn-sm btn-default' %></td>
+
+path(@team , params: {team:{owner_id:assign.id}}),method: :patch, class: 'btn btn-sm btn-default' %></td>
+
+
+
+<%= link_to "hoge", {controller: "users", action: "update", user_id: 1}, method: :post %>
+<td><%= link_to I18n.t('views.button.delegation'), team_path(@team , params: {team:{owner_id:assign.id}}),method: :patch, class: 'btn btn-sm btn-default' %></td>
+
+チームリーダーのチームページに、各チームメンバーへの権限移動ボタン
+権限ボタンを押すとそのメンバーにチームオーナー権限が移動
+チームオーナーの権限移動時、新オーナーに通知メール
+
+[Fixed]チームリーダーが、他のチームメンバーにリーダー権限を渡せる機能を実装すること


### PR DESCRIPTION
- チームのメンバー削除はチームのオーナーか、チームのユーザー自身しができないよう設定（自身を削除した場合はユーザーページへ画面遷移)
- チームの編集はチームのオーナーのみができるよう設定
