### PR TITLE
[Fixed]#8 アジェンダの削除機能を実装すること（紐づいている記事も削除し、そのアジェンダのチームに属しているメンバー全員に通知メールを送信すること）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 yarn-debug.log*
 .yarn-integrity
 /public/uploads
+memo.html

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -9,7 +9,7 @@ class AgendasController < ApplicationController
     @team = Team.friendly.find(params[:team_id])
     @agenda = Agenda.new
   end
-  
+
   def destroy
     @team = Team.find(params[:team_id])
     @agenda = Agenda.find(params[:id])

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,6 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :destroy_authentication, only: %i[destroy]
 
   def index
     @agendas = Agenda.all
@@ -11,13 +12,14 @@ class AgendasController < ApplicationController
   end
 
   def destroy
-    @team = Team.find(params[:team_id])
-    @agenda = Agenda.find(params[:id])
     if @agenda.destroy
+      @agenda.team.members.each{|member|
+      AgendaDeletedNotifyMailer.agenda_deleted_notify(@agenda,member.email).deliver
+      }
       flash.now[:notice] = I18n.t('views.messages.agenda_deleted')
       render template: 'teams/show' and return
     else
-      flash.now[:error] = I18n.t('views.messages.agenda_not_deleted')
+      flash.now[:notice] = I18n.t('views.messages.agenda_not_deleted')
       render template: 'teams/show' and return
     end
   end
@@ -41,5 +43,14 @@ class AgendasController < ApplicationController
 
   def agenda_params
     params.fetch(:agenda, {}).permit %i[title description]
+  end
+
+  def destroy_authentication
+    @team = Team.find(params[:team_id])
+    @agenda = Agenda.find(params[:id])
+    unless @agenda.user_id == current_user.id || @agenda.team.owner_id == current_user.id
+      flash.now[:notice] = I18n.t('views.messages.delete_authentication_notice')
+      render template: 'teams/show'
+    end
   end
 end

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -13,8 +13,13 @@ class AgendasController < ApplicationController
   def destroy
     @team = Team.find(params[:team_id])
     @agenda = Agenda.find(params[:id])
-    @agenda.destroy
-    render template: 'teams/show'
+    if @agenda.destroy
+      flash.now[:notice] = I18n.t('views.messages.agenda_deleted')
+      render template: 'teams/show' and return
+    else
+      flash.now[:error] = I18n.t('views.messages.agenda_not_deleted')
+      render template: 'teams/show' and return
+    end
   end
 
   def create

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -9,6 +9,13 @@ class AgendasController < ApplicationController
     @team = Team.friendly.find(params[:team_id])
     @agenda = Agenda.new
   end
+  
+  def destroy
+    @team = Team.find(params[:team_id])
+    @agenda = Agenda.find(params[:id])
+    @agenda.destroy
+    render template: 'teams/show'
+  end
 
   def create
     @agenda = current_user.agendas.build(title: params[:title])

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -60,4 +60,5 @@ class ArticlesController < ApplicationController
   def article_params
     params.fetch(:article, {}).permit %i[title content image image_cache]
   end
+
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -15,8 +15,9 @@ class ArticlesController < ApplicationController
   end
 
   def new
+    # @team = Team.find(current_user.keep_team.id)
     @agenda = Agenda.find(params[:agenda_id])
-    @team = @agenda.team
+    # @team = @agenda.team
     @article = @agenda.articles.build
   end
 
@@ -25,12 +26,13 @@ class ArticlesController < ApplicationController
   end
 
   def create
+    # team = Team.find(current_user.keep_team.id)
     agenda = Agenda.find(params[:agenda_id])
-    article = agenda.articles.build(article_params)
-    article.user = current_user
-    article.team_id = agenda.team_id
-    if article.save
-      redirect_to article_url(article), notice: I18n.t('views.messages.create_article')
+    @article = agenda.articles.build(article_params)
+    @article.user = current_user
+    @article.team_id = agenda.team_id
+    if @article.save
+      redirect_to article_url(@article), notice: I18n.t('views.messages.create_article')
     else
       render :new
     end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -24,7 +24,7 @@ class TeamsController < ApplicationController
       @team.invite_member(@team.owner)
       redirect_to @team, notice: I18n.t('views.messages.create_team')
     else
-      flash.now[:error] = I18n.t('views.messages.failed_to_save_team')
+      flash.now[:notice] = I18n.t('views.messages.failed_to_save_team')
       render :new
     end
   end
@@ -33,7 +33,7 @@ class TeamsController < ApplicationController
     if @team.update(team_params)
       redirect_to @team, notice: I18n.t('views.messages.update_team')
     else
-      flash.now[:error] = I18n.t('views.messages.failed_to_save_team')
+      flash.now[:notice] = I18n.t('views.messages.failed_to_save_team')
       render :edit
     end
   end

--- a/app/frontend/stylesheets/application.scss
+++ b/app/frontend/stylesheets/application.scss
@@ -8,3 +8,11 @@ $fa-font-path: '~font-awesome/fonts';
   width: 100%;
   height: auto;
 }
+
+.agenda_menu_icon {
+  float: right;
+}
+
+.nav_link {
+  width:100%;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,10 +17,10 @@ module ApplicationHelper
   end
 
   def select_posting_article_path(article)
-    if article.new_record?
-      agenda_articles_path(article.agenda, article)
-    else
-      article_path(article)
-    end
+      if article.new_record?
+        agenda_articles_path(article.agenda, article)
+      else
+        article_path(article)
+      end
   end
 end

--- a/app/mailers/agenda_deleted_notify_mailer.rb
+++ b/app/mailers/agenda_deleted_notify_mailer.rb
@@ -1,9 +1,9 @@
-class AssignMailer < ApplicationMailer
+class AgendaDeletedNotifyMailer < ApplicationMailer
   default from: 'from@example.com'
 
-  def assign_mail(email, password)
+  def agenda_deleted_notify(agenda,email)
+    @agenda = agenda
     @email = email
-    @password = password
     mail to: @email, subject: I18n.t('views.messages.agenda_deleted_notify')
   end
 end

--- a/app/views/agenda_deleted_notify_mailer/agenda_deleted_notify.html.erb
+++ b/app/views/agenda_deleted_notify_mailer/agenda_deleted_notify.html.erb
@@ -1,0 +1,3 @@
+<h4>To email: <%= @email %></h4>
+<h1><%= I18n.t('views.messages.agenda_deleted_notify') %></h1>
+<p><%= I18n.t('views.messages.agenda_deleted_notify_context1')+@agenda.team.name+I18n.t('views.messages.agenda_deleted_notify_context2')+@agenda.title+I18n.t('views.messages.agenda_deleted_notify_context3') %></p>

--- a/app/views/agendas/index.html.erb
+++ b/app/views/agendas/index.html.erb
@@ -13,7 +13,7 @@
     <% @agendas.includes(:articles).each do |agenda| %>
       <table>
         <tr>Agenda title:<%= agenda.title %></tr>
-        <br />
+        <br/>
         <% agenda.articles.each do |article| %>
           <li>Article title:<%= article.title %></li>
         <% end %>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,13 +1,13 @@
-<%= form_with(model: article, url: select_posting_article_path(article), local: true) do |form| %>
-  <% if article.errors.any? %>
+<%= form_with(model: @article, url: select_posting_article_path(@article), local: true) do |form| %>
+  <% if @article.errors.any? %>
     <div class="alert alert-danger alert-dismissible">
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
       <h5>
         <i class="icon fa fa-ban"></i>
-        <%= pluralize(article.errors.count, "error") %> prohibited this team from being saved:
+        <%= pluralize(@article.errors.count, "error") %> prohibited this team from being saved:
       </h5>
       <ul>
-        <% article.errors.full_messages.each do |message| %>
+        <% @article.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
       </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@ scratch. This page gets rid of all links and provides the needed markup only.
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
+    <script src="https://kit.fontawesome.com/69130ddd27.js" crossorigin="anonymous"></script>
   </head>
 
   <body class="hold-transition sidebar-mini">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,13 +30,14 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
+            <div class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
-              <p>
                 <%= agenda.title %>
-                <i class="right fa fa-angle-left"></i>
-              </p>
-            </a>
+                <div class="agenda_menu_icon">
+                  <%=link_to(content_tag(:i,'削除',class:"far fa-trash-alt"), agenda_path(agenda.id,team_id: @working_team.id),method: :delete,data: { confirm: I18n.t('views.messages.delete_agenda_confirmation')})%>
+                  <i class="right fa fa-angle-left"></i>
+                </div>
+            </div>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -254,6 +254,11 @@ ja:
       delete_agenda_confirmation: 'アジェンダを削除しますか？'
       agenda_deleted: 'アジェンダが削除されました'
       agenda_not_deleted: 'アジェンダの削除に失敗しました'
+      delete_authentication_notice: 'チームオーナーかアジェンダ作者のみ削除できます'
+      agenda_deleted_notify: 'アジェンダ削除のお知らせ'
+      agenda_deleted_notify_context1: 'DIVEINTOPOSTのチーム名「'
+      agenda_deleted_notify_context2: '」のアジェンダ「'
+      agenda_deleted_notify_context3: '」は削除されました'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -251,6 +251,7 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      delete_agenda_confirmation: 'アジェンダを削除しますか？'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -216,7 +216,7 @@ ja:
       cannot_delete_member_4_some_reason: 'なんらかの原因で、削除できませんでした。'
       failed_to_post: '投稿できませんでした...'
       create_team: 'チーム作成に成功しました！'
-      failed_to_save_team: '保存に失敗しました、、'
+      failed_to_save_team: '保存に失敗しました'
       update_team: 'チーム更新に成功しました！'
       delete_team: 'チーム削除に成功しました！'
       update_profile: 'プロフィールを編集しました！'
@@ -252,6 +252,8 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
       delete_agenda_confirmation: 'アジェンダを削除しますか？'
+      agenda_deleted: 'アジェンダが削除されました'
+      agenda_not_deleted: 'アジェンダの削除に失敗しました'
     button:
       submit: '投稿'
       edit: '編集'


### PR DESCRIPTION
各アジェンダに削除ボタンを作成
削除ボタンを押すとアジェンダと付帯しているアーティクルが削除される
アジェンダ削除をアジェンダ作成者とチームオーナーに権限縮小
アジェンダ削除時そのチームに所属しているメンバーにお知らせメール送信
アジェンダ作成時バグ修正